### PR TITLE
fix: add proper TypeScript types to Babel AST path parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@anthropic-ai/sdk": "^0.32.1",
     "@babel/parser": "^7.29.2",
     "@babel/traverse": "^7.29.0",
+    "@babel/types": "^7.29.0",
     "commander": "^12.1.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@babel/traverse':
         specifier: ^7.29.0
         version: 7.29.0
+      '@babel/types':
+        specifier: ^7.29.0
+        version: 7.29.0
       commander:
         specifier: ^12.1.0
         version: 12.1.0

--- a/src/levels/level0/parsers/javascript.ts
+++ b/src/levels/level0/parsers/javascript.ts
@@ -6,7 +6,14 @@
  */
 
 import { parse } from '@babel/parser';
-import _traverse from '@babel/traverse';
+import _traverse, { NodePath } from '@babel/traverse';
+import type {
+  ImportDeclaration,
+  Import,
+  CallExpression,
+  ExportNamedDeclaration,
+  ExportAllDeclaration,
+} from '@babel/types';
 import type { Parser, ParseResult, ImportInfo } from './types.js';
 
 // Handle CommonJS/ESM interop for @babel/traverse
@@ -45,7 +52,7 @@ export class JavaScriptParser implements Parser {
       // Traverse AST and collect imports
       traverse(ast, {
         // Static imports: import foo from 'bar'
-        ImportDeclaration(path) {
+        ImportDeclaration(path: NodePath<ImportDeclaration>) {
           imports.push({
             source: path.node.source.value,
             type: path.node.importKind === 'type' ? 'type-only' : 'static',
@@ -55,7 +62,7 @@ export class JavaScriptParser implements Parser {
         },
 
         // Dynamic imports: import('bar')
-        Import(path) {
+        Import(path: NodePath<Import>) {
           const parent = path.parent;
           if (parent.type === 'CallExpression' && parent.arguments[0]) {
             const arg = parent.arguments[0];
@@ -73,7 +80,7 @@ export class JavaScriptParser implements Parser {
         },
 
         // CommonJS: require('bar')
-        CallExpression(path) {
+        CallExpression(path: NodePath<CallExpression>) {
           if (
             path.node.callee.type === 'Identifier' &&
             path.node.callee.name === 'require' &&
@@ -89,7 +96,7 @@ export class JavaScriptParser implements Parser {
         },
 
         // Re-exports: export { foo } from 'bar'
-        ExportNamedDeclaration(path) {
+        ExportNamedDeclaration(path: NodePath<ExportNamedDeclaration>) {
           if (path.node.source) {
             imports.push({
               source: path.node.source.value,
@@ -101,7 +108,7 @@ export class JavaScriptParser implements Parser {
         },
 
         // Re-export all: export * from 'bar'
-        ExportAllDeclaration(path) {
+        ExportAllDeclaration(path: NodePath<ExportAllDeclaration>) {
           imports.push({
             source: path.node.source.value,
             type: 'static',


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation errors in the JavaScript/TypeScript parser by adding proper type annotations to Babel AST visitor method parameters.

## Problem
The CI linting workflow was failing with 5 TypeScript errors:
```
Error: src/levels/level0/parsers/javascript.ts(48,27): error TS7006: Parameter 'path' implicitly has an 'any' type.
Error: src/levels/level0/parsers/javascript.ts(58,16): error TS7006: Parameter 'path' implicitly has an 'any' type.
Error: src/levels/level0/parsers/javascript.ts(76,24): error TS7006: Parameter 'path' implicitly has an 'any' type.
Error: src/levels/level0/parsers/javascript.ts(92,32): error TS7006: Parameter 'path' implicitly has an 'any' type.
Error: src/levels/level0/parsers/javascript.ts(104,30): error TS7006: Parameter 'path' implicitly has an 'any' type.
```

## Solution
Added proper TypeScript types to all visitor method path parameters:

1. **Import declarations**: Added `NodePath` type from `@babel/traverse`
2. **AST node types**: Added specific node types from `@babel/types`:
   - `ImportDeclaration`
   - `Import`
   - `CallExpression`
   - `ExportNamedDeclaration`
   - `ExportAllDeclaration`
3. **Dependencies**: Installed `@babel/types` as a dependency

## Changes
- `src/levels/level0/parsers/javascript.ts`: Added type imports and annotations to 5 visitor methods
- `package.json`: Added `@babel/types` dependency
- `pnpm-lock.yaml`: Updated lockfile

## Testing
- ✅ All 827 tests pass
- ✅ TypeScript linting passes (`pnpm lint`)
- ✅ No breaking changes to functionality

## Type Annotations Added
```typescript
ImportDeclaration(path: NodePath<ImportDeclaration>)
Import(path: NodePath<Import>)
CallExpression(path: NodePath<CallExpression>)
ExportNamedDeclaration(path: NodePath<ExportNamedDeclaration>)
ExportAllDeclaration(path: NodePath<ExportAllDeclaration>)
```

Fixes: ci-fix

🤖 Generated with Claude Code