### PR TITLE
feat: Add --log-prompts and --log-response flags for debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Prompt and Response Logging**
+  - `--log-prompts` flag to log all prompts sent to Claude API
+  - `--log-response` flag to log all responses from Claude API
+  - Logs saved to `.repo_map/prompts/` directory in JSONL format
+  - Level-wise organization (level1, level2, level3)
+  - Each log entry includes timestamp, level, purpose, model, token counts
+  - Warning message with 5-second delay to prevent accidental large logs
+  - Useful for debugging, understanding LLM behavior, and transparency
+
 ## [0.1.0] - 2025-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,6 +86,37 @@ rmap map --status
 rmap map --update
 ```
 
+### Debugging with Prompt Logging
+
+For debugging or understanding how `rmap` analyzes your code, you can log the exact prompts and responses sent to/from Claude:
+
+```bash
+# Log only prompts (what rmap sends to Claude)
+rmap map --log-prompts
+
+# Log only responses (what Claude returns)
+rmap map --log-response
+
+# Log both prompts and responses
+rmap map --log-prompts --log-response
+```
+
+**⚠️  Warning**: These logs can become very large (multiple MB) and may contain sensitive code information. You'll see a warning with a 5-second delay before the process starts.
+
+Logs are saved to `.repo_map/prompts/` organized by level:
+- `level1_YYYY-MM-DDTHH-mm-ss.jsonl` - Repository structure detection
+- `level2_YYYY-MM-DDTHH-mm-ss.jsonl` - Work division
+- `level3_YYYY-MM-DDTHH-mm-ss.jsonl` - File annotations
+
+Each log entry includes:
+- `timestamp` - When the prompt was sent
+- `level` - Which analysis level (level1, level2, level3)
+- `purpose` - What the prompt is for
+- `model` - Which Claude model was used
+- `prompt` - The full prompt text (if `--log-prompts` enabled)
+- `response` - The full response text (if `--log-response` enabled)
+- `inputTokens` / `outputTokens` - Token usage
+
 ### Querying the Map
 
 The `get-context` command is designed to provide compact, relevant context for AI agents:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@
 import { Command } from 'commander';
 import { version } from '../version.js';
 import { mapCommand, getContextCommand } from './commands/index.js';
+import { initPromptLogger, displayLoggingWarning } from '../core/prompt-logger.js';
 
 const program = new Command();
 
@@ -14,7 +15,9 @@ const program = new Command();
 program
   .name('rmap')
   .description('A semantic repository map builder for coding agents')
-  .version(version);
+  .version(version)
+  .option('--log-prompts', 'Log all prompts sent to Claude API (can use significant disk space)')
+  .option('--log-response', 'Log all responses from Claude API (can use significant disk space)');
 
 // Register commands
 program.addCommand(mapCommand);
@@ -37,6 +40,20 @@ process.on('unhandledRejection', (reason: unknown) => {
   }
   process.exit(1);
 });
+
+// Check for logging flags before parsing to initialize logger
+const hasLogPrompts = process.argv.includes('--log-prompts');
+const hasLogResponse = process.argv.includes('--log-response');
+
+if (hasLogPrompts || hasLogResponse) {
+  const repoRoot = process.cwd();
+
+  // Display warning and wait for confirmation
+  await displayLoggingWarning(hasLogPrompts, hasLogResponse);
+
+  // Initialize the logger
+  initPromptLogger(repoRoot, hasLogPrompts, hasLogResponse);
+}
 
 // Parse command line arguments
 try {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -95,3 +95,11 @@ export {
   validateAll,
   ConfigValidationError,
 } from './validation.js';
+// Export prompt logging utilities
+export {
+  initPromptLogger,
+  isLoggingEnabled,
+  logPromptResponse,
+  displayLoggingWarning,
+} from './prompt-logger.js';
+export type { PromptLogContext } from './prompt-logger.js';

--- a/src/core/llm-client.ts
+++ b/src/core/llm-client.ts
@@ -8,6 +8,7 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { RETRY_CONFIG } from '../config/models.js';
 import { globalRateLimiter, estimateTokens } from './rate-limiter.js';
+import { logPromptResponse, type PromptLogContext } from './prompt-logger.js';
 
 /**
  * Configuration for retry behavior
@@ -35,6 +36,8 @@ export interface LLMCallOptions {
   temperature?: number;
   /** Override retry configuration for this call */
   retryConfig?: RetryConfig;
+  /** Logging context (level and purpose) for prompt/response logging */
+  logContext?: PromptLogContext;
 }
 
 /**
@@ -157,13 +160,26 @@ export class LLMClient {
           throw new Error('Unexpected response type from Claude');
         }
 
-        // Return response with usage metrics
-        return {
+        const result = {
           text: content.text,
           inputTokens: response.usage.input_tokens,
           outputTokens: response.usage.output_tokens,
           model: options.model,
         };
+
+        // Log prompt and response if logging is enabled
+        if (options.logContext) {
+          logPromptResponse(
+            options.logContext,
+            prompt,
+            result.text,
+            result.inputTokens,
+            result.outputTokens
+          );
+        }
+
+        // Return response with usage metrics
+        return result;
       } catch (error) {
         lastError = error as Error;
 

--- a/src/core/prompt-logger.ts
+++ b/src/core/prompt-logger.ts
@@ -1,0 +1,184 @@
+/**
+ * Prompt and Response Logger
+ *
+ * Logs LLM prompts and responses to JSON files for debugging and analysis.
+ * Organizes logs by level in .repo_map/prompts/ directory.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Logging context for each LLM call
+ */
+export interface PromptLogContext {
+  /** Which level this prompt is for (e.g., "level1", "level2", "level3") */
+  level: string;
+  /** Purpose/reason for this prompt (e.g., "Repository detection", "Work division") */
+  purpose: string;
+  /** Model being used */
+  model: string;
+}
+
+/**
+ * Log entry structure
+ */
+interface PromptLogEntry {
+  /** ISO timestamp when the prompt was sent */
+  timestamp: string;
+  /** Level identifier */
+  level: string;
+  /** Purpose/reason for this call */
+  purpose: string;
+  /** Model used */
+  model: string;
+  /** The prompt text (only if --log-prompts is enabled) */
+  prompt?: string;
+  /** The response text (only if --log-response is enabled) */
+  response?: string;
+  /** Input tokens used */
+  inputTokens?: number;
+  /** Output tokens generated */
+  outputTokens?: number;
+}
+
+/**
+ * Global configuration for prompt logging
+ */
+let loggingConfig = {
+  enabled: false,
+  logPrompts: false,
+  logResponses: false,
+  repoRoot: '',
+};
+
+/**
+ * Initialize prompt logging configuration
+ *
+ * @param repoRoot - Repository root directory
+ * @param logPrompts - Whether to log prompts
+ * @param logResponses - Whether to log responses
+ */
+export function initPromptLogger(
+  repoRoot: string,
+  logPrompts: boolean,
+  logResponses: boolean
+): void {
+  loggingConfig = {
+    enabled: logPrompts || logResponses,
+    logPrompts,
+    logResponses,
+    repoRoot,
+  };
+
+  if (loggingConfig.enabled) {
+    // Ensure prompts directory exists
+    const promptsDir = path.join(repoRoot, '.repo_map', 'prompts');
+    fs.mkdirSync(promptsDir, { recursive: true });
+  }
+}
+
+/**
+ * Check if logging is enabled
+ */
+export function isLoggingEnabled(): boolean {
+  return loggingConfig.enabled;
+}
+
+/**
+ * Get the log file path for a specific level
+ *
+ * @param level - Level identifier (e.g., "level1", "level2")
+ * @returns Path to the log file
+ */
+function getLogFilePath(level: string): string {
+  const timestamp = new Date().toISOString().replace(/:/g, '-').split('.')[0];
+  const filename = `${level}_${timestamp}.jsonl`;
+  return path.join(loggingConfig.repoRoot, '.repo_map', 'prompts', filename);
+}
+
+/**
+ * Log a prompt/response entry
+ *
+ * @param context - Context information about the prompt
+ * @param prompt - The prompt text
+ * @param response - Optional response text
+ * @param inputTokens - Input tokens used
+ * @param outputTokens - Output tokens generated
+ */
+export function logPromptResponse(
+  context: PromptLogContext,
+  prompt: string,
+  response?: string,
+  inputTokens?: number,
+  outputTokens?: number
+): void {
+  if (!loggingConfig.enabled) {
+    return;
+  }
+
+  const entry: PromptLogEntry = {
+    timestamp: new Date().toISOString(),
+    level: context.level,
+    purpose: context.purpose,
+    model: context.model,
+  };
+
+  // Only include prompt if flag is enabled
+  if (loggingConfig.logPrompts) {
+    entry.prompt = prompt;
+  }
+
+  // Only include response if flag is enabled
+  if (loggingConfig.logResponses && response) {
+    entry.response = response;
+  }
+
+  // Add token counts if available
+  if (inputTokens !== undefined) {
+    entry.inputTokens = inputTokens;
+  }
+  if (outputTokens !== undefined) {
+    entry.outputTokens = outputTokens;
+  }
+
+  // Write as JSON Lines format (one JSON object per line)
+  const logLine = JSON.stringify(entry) + '\n';
+  const logFile = getLogFilePath(context.level);
+
+  try {
+    fs.appendFileSync(logFile, logLine, 'utf8');
+  } catch (error) {
+    // Don't fail the main process if logging fails
+    console.warn(`Warning: Failed to write prompt log: ${error}`);
+  }
+}
+
+/**
+ * Display warning about logging and wait for user confirmation
+ *
+ * @param logPrompts - Whether prompts will be logged
+ * @param logResponses - Whether responses will be logged
+ * @returns Promise that resolves when user confirms or rejects
+ */
+export async function displayLoggingWarning(
+  logPrompts: boolean,
+  logResponses: boolean
+): Promise<void> {
+  console.log('\n⚠️  WARNING: Prompt/Response Logging Enabled\n');
+
+  if (logPrompts) {
+    console.log('  • Prompts will be logged to .repo_map/prompts/');
+  }
+  if (logResponses) {
+    console.log('  • Responses will be logged to .repo_map/prompts/');
+  }
+
+  console.log('\n  ⚠️  These logs can become very large and consume significant disk space.');
+  console.log('  ⚠️  Logs may contain sensitive code and repository information.');
+  console.log('\n  Press Ctrl+C now to cancel if this was unintentional.');
+  console.log('  Continuing in 5 seconds...\n');
+
+  // Wait 5 seconds to allow user to cancel
+  await new Promise((resolve) => setTimeout(resolve, 5000));
+}

--- a/src/levels/level1/detector.ts
+++ b/src/levels/level1/detector.ts
@@ -191,6 +191,11 @@ export async function detectStructure(
   const response = await llmClient.sendMessage(prompt, {
     model: DETECTION_MODEL,
     maxTokens: TOKEN.MAX_TOKENS_LEVEL1,
+    logContext: {
+      level: 'level1',
+      purpose: 'Repository structure detection - identifies repo name, purpose, stack, languages, entry points, modules, and conventions',
+      model: DETECTION_MODEL,
+    },
   });
 
   // Record metrics if collector provided

--- a/src/levels/level2/divider.ts
+++ b/src/levels/level2/divider.ts
@@ -172,6 +172,11 @@ export async function divideWork(
   const response = await llmClient.sendMessage(prompt, {
     model: DIVISION_MODEL,
     maxTokens: TOKEN.MAX_TOKENS_LEVEL2,
+    logContext: {
+      level: 'level2',
+      purpose: 'Work division - divides repository files into annotation tasks with agent size and execution strategy',
+      model: DIVISION_MODEL,
+    },
   });
 
   // Record metrics if collector provided

--- a/src/levels/level3/annotator.ts
+++ b/src/levels/level3/annotator.ts
@@ -103,6 +103,11 @@ async function annotateFile(
     const response = await llmClient.sendMessage(prompt, {
       model,
       maxTokens: TOKEN.MAX_TOKENS_LEVEL3,
+      logContext: {
+        level: 'level3',
+        purpose: `File annotation - extracts purpose, tags, exports, and imports for: ${metadata.path}`,
+        model,
+      },
     });
 
     // Record metrics if collector provided
@@ -135,6 +140,11 @@ async function annotateFile(
           model,
           maxTokens: TOKEN.MAX_TOKENS_LEVEL3,
           retryConfig: { maxRetries: RETRY.VALIDATION_ERROR_RETRIES },
+          logContext: {
+            level: 'level3',
+            purpose: `File annotation (retry after validation error) - extracts purpose, tags, exports, and imports for: ${metadata.path}`,
+            model,
+          },
         });
 
         // Record retry metrics


### PR DESCRIPTION
## Summary

Adds comprehensive prompt and response logging capabilities to help users understand and debug how rmap analyzes their code.

## Features

- **`--log-prompts`** flag to log all prompts sent to Claude API
- **`--log-response`** flag to log all responses from Claude API
- Logs saved to `.repo_map/prompts/` in JSONL format
- Level-wise organization (`level1_*.jsonl`, `level2_*.jsonl`, `level3_*.jsonl`)
- Each entry includes timestamp, level, purpose, model, and token counts
- Warning message with 5-second delay to prevent accidental large logs
- Integrated into `LLMClient` with optional logging context

## Log Format

```json
{
  "timestamp": "2026-04-01T12:34:56.789Z",
  "level": "level1",
  "purpose": "Repository structure detection - identifies repo name, purpose, stack, languages, entry points, modules, and conventions",
  "model": "claude-haiku-4-5-20251001",
  "prompt": "You are analyzing a code repository...",
  "response": "{\"repo_name\":\"rmap\",\"purpose\":\"...\"}",
  "inputTokens": 1234,
  "outputTokens": 567
}
```

## Usage

```bash
# Log only prompts
rmap map --log-prompts

# Log only responses  
rmap map --log-response

# Log both
rmap map --log-prompts --log-response
```

## Benefits

- Debug LLM behavior and responses
- Understand how rmap analyzes code
- Transparency into API usage
- Useful for troubleshooting validation errors
- Works with all commands (not just `rmap map`)

## Warning System

When either flag is enabled, users see:

```
⚠️  WARNING: Prompt/Response Logging Enabled

  • Prompts will be logged to .repo_map/prompts/
  • Responses will be logged to .repo_map/prompts/

  ⚠️  These logs can become very large and consume significant disk space.
  ⚠️  Logs may contain sensitive code and repository information.

  Press Ctrl+C now to cancel if this was unintentional.
  Continuing in 5 seconds...
```

## Changes

### New Files
- `src/core/prompt-logger.ts` - Core logging utility

### Modified Files
- `src/cli/index.ts` - Added CLI flags and initialization
- `src/core/llm-client.ts` - Added logging context support
- `src/core/index.ts` - Exported logging utilities
- `src/levels/level1/detector.ts` - Added logging context
- `src/levels/level2/divider.ts` - Added logging context
- `src/levels/level3/annotator.ts` - Added logging context
- `README.md` - Added debugging section
- `CHANGELOG.md` - Documented new feature

## Test Plan

- ✅ All existing tests pass (827/827)
- ✅ Build succeeds without errors
- ✅ CLI flags appear in help output
- ✅ Logs are created in correct directory structure
- ✅ Warning displays before logging starts
- ✅ Works with all commands

## Notes

- Logs contain the exact prompts sent to Claude (including any truncation)
- Level 3 prompts may be truncated for large files (>10,000 lines)
- JSONL format allows easy parsing line-by-line
- Timestamps in filenames prevent overwrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)