### PR TITLE
docs: rmap auto-update from weekly scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ rmap map --status
 
 # Update based on git changes (explicit delta update)
 rmap map --update
+
+# Explicitly resume from checkpoint (error if none exists)
+rmap map --resume
+
+# Ignore checkpoint and start fresh
+rmap map --no-resume
 ```
 
 ### Debugging with Prompt Logging

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -48,6 +48,8 @@ The `map` command is the core of `rmap`. It analyzes your codebase and generates
 | `--full` | Force a complete rebuild, ignoring existing map |
 | `--update` | Explicit delta update (re-analyzes changed files only) |
 | `--status` | Show map status without building/updating |
+| `--resume` | Explicitly resume from checkpoint (error if none exists) |
+| `--no-resume` | Ignore checkpoint and start fresh |
 
 #### Examples
 

--- a/docs/phases/phase-1-foundation.md
+++ b/docs/phases/phase-1-foundation.md
@@ -104,7 +104,7 @@ Load and validate `.repo_map/workflows.config.json`:
 ```
 
 User provides: id, name, description, files, entryPoint.
-rmap generates: reason, role, tags, keySymbols, version.
+rmap generates: reason, role, keySymbols, version.
 
 ### 5. Level Workflow (`src/levels/level-workflow/`)
 
@@ -125,7 +125,7 @@ Level 3 → Assembler builds function-graph.json → Level Workflow → Level 4
 - Name the workflow (2-5 words)
 - Describe it (1-2 sentences)
 - Fill `reason` per file (why it's in this flow)
-- Assign `role` and `tags`
+- Assign `role`
 - Prune false positives
 
 ~100 LOC.

--- a/docs/phases/phase-4-advanced.md
+++ b/docs/phases/phase-4-advanced.md
@@ -82,7 +82,6 @@ interface LanguageParser {
 
 - Handle language-specific import patterns
 - Support mixed-language workflows (JS calls Python via subprocess/IPC)
-- Language tags in workflow metadata
 
 ## Success Criteria
 


### PR DESCRIPTION
- Documented newly added CLI flags `--resume` and `--no-resume` in `README.md` and `docs/CLI.md`.
- Removed deprecated references to `tags` from phase 1 and phase 4 documentation, reflecting the system decommissioning of the tagging system.

---
*PR created automatically by Jules for task [17624733295116301670](https://jules.google.com/task/17624733295116301670) started by @Harry-0318*