### PR TITLE
docs(cli): update --help strings — 2026-04-09 (1 commands)

### DIFF
--- a/.jules/cli-help-backlog.md
+++ b/.jules/cli-help-backlog.md
@@ -1,11 +1,11 @@
 # CLI --help Backlog
 
-Last updated: 2026-04-06T23:35:00Z
+Last updated: 2026-04-09T23:54:00Z
 
 ## Completed
 - [x] rmap get-context — updated on 2026-04-06
 - [x] rmap map — updated on 2026-04-06
-- [x] rmap — updated on 2026-04-06
+- [x] rmap — updated on 2026-04-09
 
 ## Pending
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,8 +16,8 @@ program
   .name('rmap')
   .description('A semantic repository map builder for coding agents')
   .version(version)
-  .option('--log-prompts', 'boolean  Log all prompts sent to Claude API (can use significant disk space)')
-  .option('--log-response', 'boolean  Log all responses from Claude API (can use significant disk space)')
+  .option('--log-prompts', 'boolean  Log all prompts sent to LLM API (can use significant disk space)')
+  .option('--log-response', 'boolean  Log all responses from LLM API (can use significant disk space)')
   .addHelpText('after', `
 Examples:
   rmap map


### PR DESCRIPTION
Update CLI help strings to reflect that --log-prompts and --log-response apply to the generic LLM API (including Gemini) rather than just the Claude API.

Commands updated:
- rmap

Backlog updated accordingly.

---
*PR created automatically by Jules for task [14257045013124434760](https://jules.google.com/task/14257045013124434760) started by @Harry-0318*